### PR TITLE
Add API curl examples

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,3 +17,15 @@ This project is a simplified Flask backend for a multi-modal search engine. It p
    ```
 
 This will start the Flask development server and create database tables automatically.
+
+## Sample cURL Requests
+
+An example script with `curl` commands for every API endpoint is provided in
+`api_examples.sh`. Set `BASE_URL` to the address of the running Flask server and
+execute the script to test the API:
+
+```bash
+bash api_examples.sh
+```
+
+Edit the file paths or IDs in the script as needed for your environment.

--- a/backend/api_examples.sh
+++ b/backend/api_examples.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Base URL of the running Flask server
+BASE_URL="${BASE_URL:-http://localhost:5000}"
+
+# Health check
+curl "$BASE_URL/api/status"
+
+echo -e "\n"
+
+# System statistics
+curl "$BASE_URL/api/status/stats"
+
+echo -e "\n"
+
+# Upload a single file
+curl -X POST -F "file=@/path/to/file.pdf" "$BASE_URL/api/upload/file"
+
+echo -e "\n"
+
+# Upload multiple files in one request
+curl -X POST \
+  -F "files=@/path/to/file1.pdf" \
+  -F "files=@/path/to/file2.docx" \
+  "$BASE_URL/api/upload/batch"
+
+echo -e "\n"
+
+# Check upload processing status (replace 1 with actual ID)
+curl "$BASE_URL/api/upload/status/1"
+
+echo -e "\n"
+
+# List all uploaded files
+curl "$BASE_URL/api/files"
+
+echo -e "\n"
+
+# Get information about a specific file
+curl "$BASE_URL/api/files/1"
+
+echo -e "\n"
+
+# Get processed content for a file
+curl "$BASE_URL/api/files/1/content"
+
+echo -e "\n"
+
+# Delete a file
+curl -X DELETE "$BASE_URL/api/files/1"
+
+echo -e "\n"
+
+# Perform a search query
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"query": "search term"}' "$BASE_URL/api/search"
+
+echo -e "\n"
+
+# Get search suggestions
+curl "$BASE_URL/api/search/suggestions"
+
+echo -e "\n"
+
+# Get search history
+curl "$BASE_URL/api/search/history"
+
+echo -e "\n"


### PR DESCRIPTION
## Summary
- provide a simple shell script with curl calls for each API
- document the script in the backend README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b2410dbec832ea7ab6b7d9ecdc408