### PR TITLE
Fix scheduler job app context

### DIFF
--- a/backend/app/scheduler/tasks.py
+++ b/backend/app/scheduler/tasks.py
@@ -1,6 +1,6 @@
 """Background processing tasks."""
 import logging
-from flask import current_app
+from flask import current_app, Flask
 
 from .. import scheduler
 from ..services.processing_service import ProcessingService
@@ -11,11 +11,12 @@ logger = logging.getLogger(__name__)
 def schedule_processing(file_id: int) -> None:
     """Schedule file processing job."""
     job_id = f"process_file_{file_id}"
-    scheduler.add_job(id=job_id, func=process_file_job, trigger='date', args=[file_id])
+    app = current_app._get_current_object()
+    scheduler.add_job(id=job_id, func=process_file_job, trigger='date', args=[file_id, app])
 
 
-def process_file_job(file_id: int) -> None:
+def process_file_job(file_id: int, app: Flask) -> None:
     """Process file job."""
-    with current_app.app_context():
+    with app.app_context():
         service = ProcessingService()
         service.process(file_id)


### PR DESCRIPTION
## Summary
- pass the Flask app when scheduling jobs
- use that app inside scheduler tasks to create an app context

## Testing
- `python -m py_compile backend/app/scheduler/tasks.py`


------
https://chatgpt.com/codex/tasks/task_b_683b295c4b74832eb592bdc97fa17e5b