### PR TITLE
Fix embedding upload and return chunk text

### DIFF
--- a/backend/app/services/embedding_service.py
+++ b/backend/app/services/embedding_service.py
@@ -3,6 +3,8 @@ import logging
 from typing import List
 
 from qdrant_client import QdrantClient
+from qdrant_client.http.models import PointStruct
+from uuid import uuid4
 from flask import current_app
 
 from .ollama_client import OllamaClient
@@ -28,14 +30,14 @@ class EmbeddingService:
         try:
             collection = 'text_embeddings'
             logger.debug("Uploading embedding to Qdrant with metadata: %s", metadata)
-            response = self.qdrant.upload_collection(
+
+            point_id = str(uuid4())
+            self.qdrant.upsert(
                 collection_name=collection,
-                vectors=[vector],
-                payload=[metadata],
+                points=[PointStruct(id=point_id, vector=vector, payload=metadata)],
             )
-            vector_id = response[0]
-            logger.debug("Uploaded vector id: %s", vector_id)
-            return vector_id
+            logger.debug("Uploaded vector id: %s", point_id)
+            return point_id
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception("Embedding upload failed")
             return ''

--- a/backend/app/services/processing_service.py
+++ b/backend/app/services/processing_service.py
@@ -40,6 +40,7 @@ class ProcessingService:
                     'chunk_id': idx,
                     'content_type': chunk['type'],
                     'filename': file_record.filename,
+                    'content': chunk['content'],
                 }
                 vector_id = self.embedding.embed_text(chunk['content'], metadata)
                 logger.debug("Vector id returned: %s", vector_id)
@@ -50,6 +51,7 @@ class ProcessingService:
                     chunk_type=chunk['type'],
                     content_text=chunk['content'],
                     chunk_index=idx,
+                    related_metadata=metadata,
                     vector_id=vector_id,
                     embedding_model='nomic-embed-text',
                 ))


### PR DESCRIPTION
## Summary
- generate a UUID for vector IDs and upsert embeddings to Qdrant
- include chunk text in metadata and save it alongside vectors
- return chunk text from search results and use it for summarization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683b590234e0832e9ae607245788e340